### PR TITLE
Afd 106 book details logic

### DIFF
--- a/backup.json
+++ b/backup.json
@@ -1,0 +1,70 @@
+{
+    "books": [
+      {
+        "id": 1,
+        "src": "",
+        "title": "Pet Sematary",
+        "author": "Stephen King",
+        "synopsis": "The Creed family suffers a series of tragic events after relocating to a house near a busy highway. When his daughter’s beloved cat, Church, is killed by a speeding truck, Louis Creed follows his neighbor to a hidden burial ground said to bring the dead back to life. When the cat shows up alive, Louis is elated, but soon discovers that everything comes with a price.",
+        "published": "1983-11-15",
+        "pages": 373,
+        "rating": 4
+      },
+      {
+        "id": 2,
+        "title": "The Haunting of Hill House",
+        "author": "Shirley Jackson",
+        "synopsis": "An occult scholar invites a troubled young woman to join himself and two others at an old manor to search for evidence of psychic phenomena. Their sanity is put to the test when Hill House seems intent to keep them within its walls.",
+        "published": "1959-10-17",
+        "pages": 246,
+        "rating": 3
+      },
+      {
+        "id": 3,
+        "title": "Survivor",
+        "author": "Chuck Palahniuk",
+        "synopsis": "Tender Branson, the last surviving member of a death cult, recounts his life story, from childhood to fitness addict and media messiah, while he waits for his plane to crash into the Australian outback.",
+        "published": "1999-02-18",
+        "pages": 304,
+        "rating": 3
+      },
+      {
+        "id": 4,
+        "title": "Crash",
+        "author": "J.G. Ballard",
+        "synopsis": "After an horrific car accident, James is drawn into a world full of fellow crash survivors, obsessed with re-creating famous car accidents for sexual thrills.",
+        "published": "1973-07-29",
+        "pages": 224,
+        "rating": 4
+      },
+      {
+        "id": 5,
+        "title": "Spook",
+        "author": "Mary Roach",
+        "synopsis": "A scientific look through the ages at those who have dedicated their lives to finding some evidence of life after death.",
+        "published": "2005-02-11",
+        "pages": 311,
+        "rating": 5
+      },
+      {
+        "id": 6,
+        "title": "Snuff",
+        "author": "Terry Pratchett",
+        "synopsis": "Commander Sam Vimes of the Ankh-Morpork City Watch is on holiday in the pleasant and innocent countryside, but a body in the wardrobe would be far too simple. Instead he finds many, many bodies –  and an ancient crime more terrible than murder. He is out of his jurisdiction, out of his depth, out of bacon sandwiches and out of his mind, but never out of guile. Where there is a crime there must be a punishment.",
+        "published": "2011-10-12",
+        "pages": 378,
+        "rating": 5
+      },
+      {
+        "src": "",
+        "title": "A Long Dark Hall",
+        "author": "Liv Heller",
+        "synopsis": "There is a hallway. It is long. Also dark.",
+        "published": "",
+        "pages": 1,
+        "rating": 5,
+        "id": "VW-nn1Kk1"
+      }
+    ]
+  }
+  

--- a/db.json
+++ b/db.json
@@ -57,153 +57,23 @@
     },
     {
       "src": "",
-      "title": "What the Hell Did I Just Read?",
-      "author": "David Wong",
-      "synopsis": "In the final book of the John Dies at the End trilogy, David and John must, once again, battle interdimensional creatures intent on torturing the inhabitants of Unnamed and clearing David's name as the town's most recognized child killer.",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "wfrZnyIn0"
-    },
-    {
-      "src": "",
       "title": "A Long Dark Hall",
       "author": "Liv Heller",
-      "synopsis": "There is a hallway. It is dark. It is also long.",
-      "published": "1990-03-11T17:06:28.084Z",
-      "pages": 25,
-      "rating": 1,
-      "id": "sgRPCmAyC"
-    },
-    {
-      "src": "",
-      "title": "dsfadfs",
-      "author": "asdfdsf",
-      "synopsis": "jklghhkhlhl",
+      "synopsis": "There is a hallway. It is long. Also dark.",
       "published": "",
-      "pages": 294,
+      "pages": 1,
       "rating": 5,
-      "id": "AwnsFBEMO"
+      "id": "VW-nn1Kk1"
     },
     {
       "src": "",
-      "title": "",
-      "author": "",
-      "synopsis": "hgkhkhkjhkjg",
-      "published": "2021-11-01T21:22:24.166Z",
-      "pages": 296,
-      "rating": 3,
-      "id": "oxLCLA7IK"
-    },
-    {
-      "src": "",
-      "title": "kjhlkjhl",
-      "author": "",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "_pIXPA_2z"
-    },
-    {
-      "src": "",
-      "title": "",
-      "author": "",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "LolkOve9G"
-    },
-    {
-      "src": "",
-      "title": "",
-      "author": "",
-      "synopsis": "khgkjhgj",
-      "published": "",
-      "pages": "",
-      "rating": 4,
-      "id": "kExPfn5LS"
-    },
-    {
-      "src": "",
-      "title": "dfssdfsd",
-      "author": "adsasd",
-      "synopsis": "hgkjhgjkghjk",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "p0jsEnVnA"
-    },
-    {
-      "src": "",
-      "title": "",
-      "author": "hgkh",
-      "synopsis": "sdsafsaf",
-      "published": "1997-02-02T01:27:35.543Z",
-      "pages": 309,
-      "rating": 3,
-      "id": "fuv_Y-bUK"
-    },
-    {
-      "src": "",
-      "title": "fds",
-      "author": "",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "OAOZVIeEX"
-    },
-    {
-      "src": "",
-      "title": "",
-      "author": "",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "geAxJAznB"
-    },
-    {
-      "src": "",
-      "title": "sd",
-      "author": "dssd",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "oXYcNSbGU"
-    },
-    {
-      "src": "",
-      "title": "dsfsdf",
-      "author": "sdf",
-      "synopsis": "",
-      "published": "",
-      "pages": "",
-      "rating": 0,
-      "id": "EN7XcNfX_"
-    },
-    {
-      "src": "",
-      "title": "sdaa",
-      "author": "asdas",
-      "synopsis": "",
-      "published": "2021-11-03T02:50:52.954Z",
-      "pages": 300,
-      "rating": 0,
-      "id": "QHRd24a6V"
-    },
-    {
-      "src": "",
-      "title": "A long stare",
-      "author": "me ",
-      "synopsis": "stuff happens",
-      "published": "1993-03-12T03:58:36.562Z",
-      "pages": 311,
-      "rating": 3,
-      "id": "2TpSGN-xu"
+      "title": "A Boring Book",
+      "author": "Liv Heller",
+      "synopsis": "Nothing Happens.",
+      "published": "1993-06-10T19:59:26.637Z",
+      "pages": 1,
+      "rating": 1,
+      "id": "pVzf_k0OD"
     }
   ]
 }

--- a/db.json
+++ b/db.json
@@ -6,7 +6,7 @@
       "title": "Pet Sematary",
       "author": "Stephen King",
       "synopsis": "The Creed family suffers a series of tragic events after relocating to a house near a busy highway. When his daughter’s beloved cat, Church, is killed by a speeding truck, Louis Creed follows his neighbor to a hidden burial ground said to bring the dead back to life. When the cat shows up alive, Louis is elated, but soon discovers that everything comes with a price.",
-      "published": "Nov 14, 1983",
+      "published": "1983-11-15",
       "pages": 373,
       "rating": 4
     },
@@ -15,7 +15,7 @@
       "title": "The Haunting of Hill House",
       "author": "Shirley Jackson",
       "synopsis": "An occult scholar invites a troubled young woman to join himself and two others at an old manor to search for evidence of psychic phenomena. Their sanity is put to the test when Hill House seems intent to keep them within its walls.",
-      "published": "Oct 16, 1959",
+      "published": "1959-10-17",
       "pages": 246,
       "rating": 3
     },
@@ -24,7 +24,7 @@
       "title": "Survivor",
       "author": "Chuck Palahniuk",
       "synopsis": "Tender Branson, the last surviving member of a death cult, recounts his life story, from childhood to fitness addict and media messiah, while he waits for his plane to crash into the Australian outback.",
-      "published": "Feb 17, 1999",
+      "published": "1999-02-18",
       "pages": 304,
       "rating": 3
     },
@@ -33,7 +33,7 @@
       "title": "Crash",
       "author": "J.G. Ballard",
       "synopsis": "After an horrific car accident, James is drawn into a world full of fellow crash survivors, obsessed with re-creating famous car accidents for sexual thrills.",
-      "published": "June 28th, 1973",
+      "published": "1973-07-29",
       "pages": 224,
       "rating": 4
     },
@@ -42,7 +42,7 @@
       "title": "Spook",
       "author": "Mary Roach",
       "synopsis": "A scientific look through the ages at those who have dedicated their lives to finding some evidence of life after death.",
-      "published": "Oct 2005",
+      "published": "2005-02-11",
       "pages": 311,
       "rating": 5
     },
@@ -51,7 +51,7 @@
       "title": "Snuff",
       "author": "Terry Pratchett",
       "synopsis": "Commander Sam Vimes of the Ankh-Morpork City Watch is on holiday in the pleasant and innocent countryside, but a body in the wardrobe would be far too simple. Instead he finds many, many bodies –  and an ancient crime more terrible than murder. He is out of his jurisdiction, out of his depth, out of bacon sandwiches and out of his mind, but never out of guile. Where there is a crime there must be a punishment.",
-      "published": "10/11/2011",
+      "published": "2011-10-12",
       "pages": 378,
       "rating": 5
     },
@@ -64,16 +64,6 @@
       "pages": 1,
       "rating": 5,
       "id": "VW-nn1Kk1"
-    },
-    {
-      "src": "",
-      "title": "A Boring Book",
-      "author": "Liv Heller",
-      "synopsis": "Nothing Happens.",
-      "published": "1993-06-10T19:59:26.637Z",
-      "pages": 1,
-      "rating": 1,
-      "id": "pVzf_k0OD"
     }
   ]
 }

--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Jacket from '../styles/images/snuff.jpg';
 
 const BookCard = ({ book: { id, src, title, author } }) => {
+  // const { id, src, title, author } = book;
   return (
     <div className="card card__withImg">
       <Link to={`/details/${id}`} className="card__link">

--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import Jacket from '../styles/images/snuff.jpg';
 
 const BookCard = ({ book: { id, src, title, author } }) => {
-  // const { id, src, title, author } = book;
   return (
     <div className="card card__withImg">
       <Link to={`/details/${id}`} className="card__link">

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 
-const Button = ({ text, type, className }) => {
+const Button = ({ text, type, className, onClick }) => {
   return (
-    <button type={type} className={`btn btn__${className}`}>
+    <button type={type} className={`btn btn__${className}`} onClick={onClick}>
       {text}
     </button>
   );
@@ -12,11 +12,13 @@ Button.defaultProps = {
   type: 'button',
   text: '',
   className: '',
+  onClick: () => {},
 };
 Button.propTypes = {
   text: PropTypes.string,
   type: PropTypes.string,
   className: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default Button;

--- a/src/components/CustomPage.jsx
+++ b/src/components/CustomPage.jsx
@@ -17,7 +17,7 @@ const CustomPage = ({ handlePagesChange, reset, setReset }) => {
       <div className="form__selectPage">
         <NumberPicker
           defaultValue={300}
-          min={0}
+          min={1}
           value={pages}
           name="pages"
           onChange={(pages) => {

--- a/src/components/Stars.jsx
+++ b/src/components/Stars.jsx
@@ -66,12 +66,16 @@ Stars.defaultProps = {
   setReset: () => {},
   reset: false,
   className: '',
+  id: '',
+  rating: 0,
 };
 Stars.propTypes = {
   handleRatingChange: PropTypes.func,
   setReset: PropTypes.func,
   reset: PropTypes.bool,
   className: PropTypes.string,
+  id: PropTypes.string,
+  rating: PropTypes.number,
 };
 
 export default Stars;

--- a/src/components/Stars.jsx
+++ b/src/components/Stars.jsx
@@ -1,8 +1,20 @@
 import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { FaStar } from 'react-icons/fa';
 
-const Stars = ({ handleRatingChange, reset, setReset }) => {
+const Stars = ({
+  handleRatingChange,
+  reset,
+  setReset,
+  className,
+  id,
+  rating,
+}) => {
+  const pathname = useLocation();
+  const path = pathname.pathname;
+  const detailsPath = `/details/${id}`;
+  const bookRating = rating;
   const [currentRating, setCurrentRating] = useState(0);
 
   useEffect(() => {
@@ -11,26 +23,37 @@ const Stars = ({ handleRatingChange, reset, setReset }) => {
   }, [reset]);
 
   return (
-    <div className="form__rating">
+    <div className={`form__rating form__rating--${className}`}>
       {[...Array(5)].map((_star, index) => {
         const givenRating = index + 1;
         return (
           <div className="form__rating--stars" key={givenRating}>
-            <FaStar
-              type="radio"
-              role="button"
-              name="rating"
-              value={givenRating}
-              className={
-                givenRating <= currentRating || givenRating === currentRating
-                  ? 'form__rating--checked'
-                  : 'form__rating--unchecked'
-              }
-              onClick={() => {
-                handleRatingChange(givenRating);
-                setCurrentRating(givenRating);
-              }}
-            />
+            {path === detailsPath ? (
+              <FaStar
+                style={{ cursor: 'default' }}
+                className={
+                  givenRating <= bookRating || givenRating === bookRating
+                    ? 'form__rating--checked disabled'
+                    : 'form__rating--unchecked disabled'
+                }
+              />
+            ) : (
+              <FaStar
+                type="radio"
+                role="button"
+                name="rating"
+                value={givenRating}
+                className={
+                  givenRating <= currentRating || givenRating === currentRating
+                    ? 'form__rating--checked'
+                    : 'form__rating--unchecked'
+                }
+                onClick={() => {
+                  handleRatingChange(givenRating);
+                  setCurrentRating(givenRating);
+                }}
+              />
+            )}
           </div>
         );
       })}
@@ -42,11 +65,13 @@ Stars.defaultProps = {
   handleRatingChange: () => {},
   setReset: () => {},
   reset: false,
+  className: '',
 };
 Stars.propTypes = {
   handleRatingChange: PropTypes.func,
   setReset: PropTypes.func,
   reset: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default Stars;

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -1,21 +1,33 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useHistory } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { getBook } from '../utils/API';
+import { getBook, deleteBook } from '../utils/API';
 import Button from '../components/Button';
 import Stars from '../components/Stars';
 import Jacket from '../styles/images/snuff.jpg';
 import EmptyCard from '../components/EmptyCard';
 
 const Details = () => {
+  const history = useHistory();
   const [book, setBook] = useState({});
   const { id } = useParams();
   const { title, author, synopsis, published, pages } = book;
+
+  const p = new Date(published);
+  const month = p.getMonth() + 1;
+  const day = p.getDate();
+  const year = p.getFullYear();
 
   useEffect(() => {
     getBook(id)
       .then(({ data: book }) => setBook(book))
       .catch((err) => console.log(err));
   }, [id]);
+
+  const deleteThisBook = () => {
+    deleteBook(id)
+      .then(() => history.push('/bookshelf'))
+      .catch((err) => console.log(err));
+  };
 
   return (
     <div className="details grid">
@@ -28,7 +40,7 @@ const Details = () => {
       <h2 className="details__text details__text--author desktop">{author}</h2>
 
       <h3 className=" details__text details__text--published">
-        Published: {published}
+        Published: {`${month}/${day}/${year}`}
       </h3>
       <h3 className="details__text details__text--pages">{pages} Pages</h3>
       <p className="details__text details__text--synopsis">
@@ -36,6 +48,7 @@ const Details = () => {
       </p>
 
       <div className="details__btns">
+        <Button text="Delete Book" type="button" onClick={deleteThisBook} />
         <Link to={`/editBook/${id}`}>
           <Button text="Edit This Book" type="button" className="editBtn" />
         </Link>

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -5,12 +5,13 @@ import Button from '../components/Button';
 import Stars from '../components/Stars';
 import Jacket from '../styles/images/snuff.jpg';
 import EmptyCard from '../components/EmptyCard';
+import { FaStar } from 'react-icons/fa';
 
 const Details = () => {
   const history = useHistory();
   const [book, setBook] = useState({});
   const { id } = useParams();
-  const { title, author, synopsis, published, pages } = book;
+  const { title, author, synopsis, published, pages, rating } = book;
 
   const p = new Date(published);
   const month = p.getMonth() + 1;
@@ -36,19 +37,26 @@ const Details = () => {
       <h2 className="details__text details__text--author mobile">{author}</h2>
       <h3 className="details__text details__text--rating mobile">Rating</h3>
 
-      <Stars className="details" type="checked" />
+      <Stars className="details" id={id} rating={rating} />
       <h2 className="details__text details__text--author desktop">{author}</h2>
 
       <h3 className=" details__text details__text--published">
-        Published: {`${month}/${day}/${year}`}
+        Published: {published ? `${month}/${day}/${year}` : ''}
       </h3>
-      <h3 className="details__text details__text--pages">{pages} Pages</h3>
+      <h3 className="details__text details__text--pages">
+        {pages || ''} Pages
+      </h3>
       <p className="details__text details__text--synopsis">
         <q>{synopsis}</q>
       </p>
+      <Button
+        text="Delete Book"
+        className="delete"
+        type="button"
+        onClick={deleteThisBook}
+      />
 
       <div className="details__btns">
-        <Button text="Delete Book" type="button" onClick={deleteThisBook} />
         <Link to={`/editBook/${id}`}>
           <Button text="Edit This Book" type="button" className="editBtn" />
         </Link>

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -5,7 +5,6 @@ import Button from '../components/Button';
 import Stars from '../components/Stars';
 import Jacket from '../styles/images/snuff.jpg';
 import EmptyCard from '../components/EmptyCard';
-import { FaStar } from 'react-icons/fa';
 
 const Details = () => {
   const history = useHistory();

--- a/src/pages/EditBook.jsx
+++ b/src/pages/EditBook.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import Button from '../components/Button';
 import BookForm from '../components/BookForm';
 import Jacket from '../styles/images/snuff.jpg';
 
@@ -15,15 +14,6 @@ const EditBook = ({ src, title, author, synopsis, published, pages }) => {
         published={published}
         pages={pages}
       />
-      {/* <div className="editBook__btns">
-        <Button
-          text="Submit"
-          type="submit"
-          form="editBookForm"
-          className="submit"
-        />
-        <Button text="Cancel" type="reset" className="light leftBtn" />
-      </div> */}
     </div>
   );
 };

--- a/src/pages/EditBook.jsx
+++ b/src/pages/EditBook.jsx
@@ -15,7 +15,7 @@ const EditBook = ({ src, title, author, synopsis, published, pages }) => {
         published={published}
         pages={pages}
       />
-      <div className="editBook__btns">
+      {/* <div className="editBook__btns">
         <Button
           text="Submit"
           type="submit"
@@ -23,7 +23,7 @@ const EditBook = ({ src, title, author, synopsis, published, pages }) => {
           className="submit"
         />
         <Button text="Cancel" type="reset" className="light leftBtn" />
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -72,7 +72,10 @@
         margin: 2rem 0;
         &--details {
             justify-self: center;
-            margin-top: 0;
+            align-items: baseline;
+            margin: 1rem 0 0 1rem;
+            grid-column: 1;
+            font-size: 2.5rem;
         }
         &--stars {
             padding-right: .5rem;

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -184,9 +184,8 @@
     }
     @media only screen and (max-width: 425px) {
         &__rating {
-            font-size: 2rem;
             &--details {
-                margin: 0 3rem 0 6rem;
+                margin: 0 3rem 0 4rem;
             }
         }
     }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -30,9 +30,7 @@
         height: 3rem;
         font-size: 1rem;
         grid-row: 1;
-    }
-    @media only screen and (max-width: 1024px) {
-        width: 14rem;
+        background-color: v.$red;
     }
     @media only screen and (max-width: 769px) {
         width: 13rem;
@@ -41,12 +39,26 @@
             width: 10rem;
             margin-bottom: 1rem;
         }
+        &__delete {
+            grid-row: 4;
+            grid-column: 3;
+            width: 7rem;
+            height: 2.5rem;
+            align-self: flex-start;
+            font-size: .8rem;
+        }
     }
     @media only screen and (max-width: 480px) {
         width: 14rem;
         font-size: 1.5rem;
         &__mdDark {
             width: 17rem;
+        }
+        &__delete {
+            width: 11rem;
+            font-size: 1rem;
+            position: relative;
+            top: 14rem;
         }
     }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -16,12 +16,20 @@
     font-size: 1.5rem;
     background-color: v.$coffee;
     color: white;
+    cursor: pointer;
     &__light {
         background-color: lighten(v.$coffee, 75%);
         color: black;
     }
     &__mdDark {
         background-color: lighten(v.$coffee, 25%);
+    }
+    &__delete {
+        place-self: center left;
+        width: 8rem;
+        height: 3rem;
+        font-size: 1rem;
+        grid-row: 1;
     }
     @media only screen and (max-width: 1024px) {
         width: 14rem;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -6,3 +6,4 @@ $beige: #f2e9d8;
 $brown: #b1a899;
 $green: #8b8d84;
 $blue: #42f5f5;
+$red: #905f5f;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -514,6 +514,11 @@ body {
 
     }
   }
+  @media only screen and (max-width: 1300px) {
+    .details {
+      column-gap: 2rem;
+    }
+  }
   @media only screen and (max-width: 1200px) {
     .details {
       padding: 10rem 4rem 0;
@@ -522,6 +527,10 @@ body {
   @media only screen and (max-width: 1025px) {
     .details {
       column-gap: 2rem;
+      padding-top: 6rem;
+      &__btns {
+        margin: 3rem 0 5rem;
+      }
       &__img {
         width: 15rem;
         align-self: center;
@@ -530,14 +539,16 @@ body {
   }
   @media only screen and (max-width: 769px) {
     .details {
-      padding: 3rem 1rem 0 2rem;
+      padding: 5rem 1rem 0 2rem;
       margin-bottom: 0;
       &__img {
         width: 13rem;
       }
       &__text {
+        grid-column: 2/4;
         &--synopsis {
           font-size: 1.3rem;
+          grid-column: 2/4;
         }
       }
       .form {
@@ -553,24 +564,26 @@ body {
   }
   @media only screen and (max-width: 480px) {
     .details {
+      display: block;
+      padding: 2rem 3rem 12rem;
+      text-align: center;
       .mobile {
         display: block;
       }
       .desktop {
         display: none;
       }
-      display: block;
-      padding: 1rem 3rem 5rem;
       &__text {
         text-align: center;
+        font-size: 2rem;
         &--title {
           font-size: 3rem;
           margin-bottom: 0;
         }
         &--author {
-          font-size: 2rem;
+          font-size: 2.5rem;
           margin-top: 0;
-          padding-top: 2rem;
+          padding-top: 1rem;
         }
         &--rating {
           margin: 3rem 0 1rem;
@@ -590,24 +603,32 @@ body {
       }
       &__img {
         margin: 2rem auto;
+        width: 19rem;
       }
       &__btns {
         text-align: center;
+        margin-top: 0;
       }
     }
   }
   @media only screen and (max-width: 425px) {
     .details {
+      padding-bottom: 9rem;
+      &__text {
+        &--synopsis {
+          font-size: 1.5rem;
+        }
+      }
       .form {
         &__rating {
-          font-size: 1.5rem;
+          font-size: 2rem;
         }
       }
     }
   }
   @media only screen and (max-width: 375px) {
     .details {
-      padding: 1rem 3rem 3rem;
+      padding: 1rem 1rem 11rem;
       &__text {
         &--author {
           margin: 2rem 0 1rem;
@@ -615,8 +636,12 @@ body {
         &--published {
           margin-top: 2rem;
         }
+        &--synopsis {
+          padding: 0 1rem;
+        }
       }
       &__img {
+        width: 16rem;
         &--mobile {
           width: 65%;
         }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -471,7 +471,7 @@ body {
     grid-template-columns: 1fr 2fr;
     grid-template-rows: .5fr .5fr 1fr .5fr .5fr;
     padding: 11rem 10rem 0;
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
     &__img {
       grid-column: 1;
     }
@@ -484,7 +484,7 @@ body {
       &--author {
         grid-row: 1;
         align-self: end;
-        padding-top: 6rem;
+        padding-top: 7rem;
       }
       &--published,
       &--pages {
@@ -509,6 +509,9 @@ body {
   
     &__btns {
       @include m.lowerPageBtns;
+      margin: 1rem 0;
+      grid-column: 1/5;
+
     }
   }
   @media only screen and (max-width: 1200px) {

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -21,3 +21,7 @@ export const addBook = (book) => {
     },
   });
 };
+
+export const deleteBook = (id) => {
+  return axios.delete(`${url}/${id}`);
+};


### PR DESCRIPTION
Clicking on a book in the bookshelf will display a details page with the books stored info displayed. A delete button allows you to delete the book and an edit button will take you to an edit page that has not been set-up yet.

Changed way dates are displayed, added delete button and functionality, added to the stars logic to be disabled when on the details page. No way to add book jacket images at this time

known issues: bottom margin at 769px 